### PR TITLE
Adds suport for sending an extra header on HTTP tests

### DIFF
--- a/doc/json/http.json
+++ b/doc/json/http.json
@@ -32,6 +32,12 @@
 
       "http://g1.globo.com/index.html": {
         "match": "<html"
+      },
+
+      "186.192.90.5": {
+        "send_header": "Host: globo.com",
+        "code": 301,
+        "expect_header": "Location: http://www.globo.com/"
       }
     }
   }


### PR DESCRIPTION
This patch adds a new parameter to HTTP tests, so one extra header field is sent with the request.
